### PR TITLE
Move to flit changes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,9 +8,9 @@ version: 2
 python:
   version: "3.8"
   install:
-      - method: pip
-        path: .
-        extra_requirements:
+    - method: pip
+      path: .
+      extra_requirements:
         - docs
 
 sphinx:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,22 +13,14 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
-
+import firecrest
 
 # -- Project information -----------------------------------------------------
 
 project = 'PyFirecREST'
 copyright = '2022, CSCS Swiss National Supercomputing Center'
 author = 'CSCS Swiss National Supercomputing Center'
-
-# The full version, including alpha/beta/rc tags
-version_py = os.path.join(os.path.dirname(__file__), '../..', 'firecrest', 'version.py')
-version_d = {}
-with open(version_py) as fp:
-    exec(fp.read(), version_d)
-
-release = version_d['VERSION']
-
+release = firecrest.__version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/firecrest/version.py
+++ b/firecrest/version.py
@@ -1,9 +1,0 @@
-#
-#  Copyright (c) 2019-2022, ETH Zurich. All rights reserved.
-#
-#  Please, refer to the LICENSE file in the root directory.
-#  SPDX-License-Identifier: BSD-3-Clause
-#
-from . import __version__
-
-VERSION = __version__


### PR DESCRIPTION
Remove `version.py` file, as far as I can tell we don't need it anymore. Docs were also failing with:
```bash
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyfirecrest/envs/38/lib/python3.8/site-packages/sphinx/config.py", line 350, in eval_config_file
    exec(code, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/pyfirecrest/checkouts/38/docs/source/conf.py", line 28, in <module>
    exec(fp.read(), version_d)
  File "<string>", line 7, in <module>
KeyError: "'__name__' not in globals"
```